### PR TITLE
Feat/rsync image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM alpine:latest
-
-# Update
-RUN apk --update --no-cache add rsync bash openssh-client
+FROM drinternet/rsync:1.0.1
 
 # Copy entrypoint
-ADD entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
-set -eu
-
 # Start the SSH agent and load key.
 source agent-start "$GITHUB_ACTION"
 echo "$INPUT_REMOTE_KEY" | agent-add
 
-# Do deployment
+# Add strict errors and deploy.
+set -eu
 sh -c "rsync $INPUT_SWITCHES -e 'ssh -o StrictHostKeyChecking=no -p $INPUT_REMOTE_PORT $INPUT_RSH' $GITHUB_WORKSPACE/$INPUT_PATH $INPUT_REMOTE_USER@$INPUT_REMOTE_HOST:$INPUT_REMOTE_PATH"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,10 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -eu
 
-# Set deploy key
-SSH_PATH="$HOME/.ssh"
-
-# Create .ssh dir if it doesn't exist
-[ -d "$SSH_PATH" ] || mkdir "$SSH_PATH"
-
-# Place deploy_key into .ssh dir
-echo "$INPUT_REMOTE_KEY" > "$SSH_PATH/key"
-
-# Set r+w to user only
-chmod 600 "$SSH_PATH/key"
+# Start the SSH agent and load key.
+source agent-start "$GITHUB_ACTION"
+echo "$INPUT_REMOTE_KEY" | agent-add
 
 # Do deployment
-sh -c "rsync $INPUT_SWITCHES -e 'ssh -i $SSH_PATH/key -o StrictHostKeyChecking=no -p $INPUT_REMOTE_PORT $INPUT_RSH' $GITHUB_WORKSPACE/$INPUT_PATH $INPUT_REMOTE_USER@$INPUT_REMOTE_HOST:$INPUT_REMOTE_PATH"
+sh -c "rsync $INPUT_SWITCHES -e 'ssh -o StrictHostKeyChecking=no -p $INPUT_REMOTE_PORT $INPUT_RSH' $GITHUB_WORKSPACE/$INPUT_PATH $INPUT_REMOTE_USER@$INPUT_REMOTE_HOST:$INPUT_REMOTE_PATH"


### PR DESCRIPTION
Switch over to the rsync base image
- No need to run apk commands.
- Smaller image (removed apk cache).

Minor changes to Dockerfile.
- Follows [best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy).

Minor change to entrypoint.
- Uses utilities provided in base image.
- Doesn't require bash.

irl testing shows a decrease in run time times from 27-32 seconds to 23 seconds, using the same load and rsync settings.