### PR TITLE
Release/v5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drinternet/rsync:1.1.0
+FROM drinternet/rsync:v1.2.0
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drinternet/rsync:1.0.1
+FROM drinternet/rsync:1.1.0
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ The underlaying base-image of the docker-image is very small (Alpine (no cache))
 
 - `remote_key`* - The remote ssh key
 
+- `remote_key_pass` - The remote ssh key passphrase (if any)
+
 ``* = Required``
 
-## Required secret
+## Required secret(s)
 
-This action needs a `DEPLOY_KEY` secret variable. This should be the private key part of a ssh key pair. The public key part should be added to the authorized_keys file on the server that receives the deployment. This should be set in the Github secrets section and then referenced as the  `remote_key` input.
+This action needs a secret variable for the ssh private key of your ssh key pair. The public key part should be added to the authorized_keys file on the server that receives the deployment. The secret variable should be set in the Github secrets section of your org/repo and then referenced as the  `remote_key` input.
+
+For simplicity, we are using `DEPLOY_*` as the secret variables throughout the examples.
 
 ## Example usage
 
@@ -49,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@4.1
+      uses: burnett01/rsync-deployments@5.0
       with:
         switches: -avzr --delete
         path: src/
@@ -68,7 +72,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@4.1
+      uses: burnett01/rsync-deployments@5.0
       with:
         switches: -avzr --delete --exclude="" --include="" --filter=""
         path: src/
@@ -79,7 +83,7 @@ jobs:
         remote_key: ${{ secrets.DEPLOY_KEY }}
 ```
 
-For better security, I suggest you create additional secrets for remote_host, remote_port and remote_user inputs.
+For better security, I suggest you create additional secrets for remote_host, remote_port, remote_user and remote_path inputs.
 
 ```
 jobs:
@@ -88,16 +92,49 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@4.1
+      uses: burnett01/rsync-deployments@5.0
       with:
         switches: -avzr --delete
         path: src/
-        remote_path: /var/www/html/
+        remote_path: ${{ secrets.DEPLOY_PATH }}
         remote_host: ${{ secrets.DEPLOY_HOST }}
         remote_port: ${{ secrets.DEPLOY_PORT }}
         remote_user: ${{ secrets.DEPLOY_USER }}
         remote_key: ${{ secrets.DEPLOY_KEY }}
 ```
+
+If your private key is passphrase protected you should use:
+
+```
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: rsync deployments
+      uses: burnett01/rsync-deployments@5.0
+      with:
+        switches: -avzr --delete
+        path: src/
+        remote_path: ${{ secrets.DEPLOY_PATH }}
+        remote_host: ${{ secrets.DEPLOY_HOST }}
+        remote_port: ${{ secrets.DEPLOY_PORT }}
+        remote_user: ${{ secrets.DEPLOY_USER }}
+        remote_key: ${{ secrets.DEPLOY_KEY }}
+        remote_key_pass: ${{ secrets.DEPLOY_KEY_PASS }}
+```
+---
+
+## Version 4.0 & 4.1
+
+Looking for version 4.0 and 4.1?
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/4.0
+- https://github.com/Burnett01/rsync-deployments/tree/4.1
+
+Version 4.0 & 4.1 use the ``drinternet/rsync:1.0.1`` base-image.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Version 3.0 uses the ``alpine:latest`` base-image directly.<br>
 Consider upgrading to 4.0 that uses a docker-image ``drinternet/rsync:1.0.1`` that is<br>
 based on ``alpine:latest``and heavily optimized for rsync.
 
-## Version 2.0
+## Version 2.0 (EOL)
 
 Looking for version 2.0?
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The underlaying base-image of the docker-image is very small (Alpine (no cache))
 
 ## Required secret(s)
 
-This action needs a secret variable for the ssh private key of your ssh key pair. The public key part should be added to the authorized_keys file on the server that receives the deployment. The secret variable should be set in the Github secrets section of your org/repo and then referenced as the  `remote_key` input.
+This action needs secret variables for the ssh private key of your key pair. The public key part should be added to the authorized_keys file on the server that receives the deployment. The secret variable should be set in the Github secrets section of your org/repo and then referenced as the  `remote_key` input.
+
+> Always use secrets when dealing with sensitive inputs!
 
 For simplicity, we are using `DEPLOY_*` as the secret variables throughout the examples.
 
@@ -83,7 +85,7 @@ jobs:
         remote_key: ${{ secrets.DEPLOY_KEY }}
 ```
 
-For better security, I suggest you create additional secrets for remote_host, remote_port, remote_user and remote_path inputs.
+For better **security**, I suggest you create additional secrets for remote_host, remote_port, remote_user and remote_path inputs.
 
 ```
 jobs:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,12 @@ The following versions are currently being supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 5.0   | :white_check_mark: |
 | 4.1   | :white_check_mark: |
 | 4.0   | :white_check_mark: |
 | 3.0   | :white_check_mark: |
-| < 2.0   | :x:                |
+| 2.0   | :x:                |
+| 1.0   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
   remote_key:
     description: 'The remote key'
     required: true
+  remote_key_pass:
+    description: 'The remote key passphrase'
+    required: false
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ inputs:
   remote_key_pass:
     description: 'The remote key passphrase'
     required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Start the SSH agent and load key.
 source agent-start "$GITHUB_ACTION"
-echo "$INPUT_REMOTE_KEY" | agent-add
+echo "$INPUT_REMOTE_KEY" | SSH_PASS="$INPUT_REMOTE_KEY_PASS" agent-add
 
 # Add strict errors.
 set -eu


### PR DESCRIPTION
New feature(s):

+ Support for passphrase protected private keys with ``remote_key_pass``
+ Update base image from JoshPiper/rsync-docker@1.0.1 to v2.1.0

Check the readme on how to use this new feature.

More technical information about the passphrase feature works:

https://github.com/JoshPiper/rsync-docker/pull/3#issue-701661145