### PR TITLE
Release/v5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drinternet/rsync:v1.2.0
+FROM drinternet/rsync:v1.3.0
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub Action deploys files in `GITHUB_WORKSPACE` to a remote folder via rs
 
 Use this action in a CD workflow which leaves deployable code in `GITHUB_WORKSPACE`.
 
-The base-image (drinternet/rsync) of this action is very small and is based on Alpine (no cache) which results in fast deployments.
+The base-image (drinternet/rsync) of this action is very small and is based on Alpine 3.14.1 (no cache) which results in fast deployments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub Action deploys files in `GITHUB_WORKSPACE` to a remote folder via rs
 
 Use this action in a CD workflow which leaves deployable code in `GITHUB_WORKSPACE`.
 
-The underlaying base-image of the docker-image is very small (Alpine (no cache)) which results in fast deployments.
+The base-image (drinternet/rsync) of this action is very small and is based on Alpine (no cache) which results in fast deployments.
 
 ---
 
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@5.0
+      uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete
         path: src/
@@ -74,7 +74,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@5.0
+      uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete --exclude="" --include="" --filter=""
         path: src/
@@ -94,7 +94,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@5.0
+      uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete
         path: src/
@@ -114,7 +114,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@5.0
+      uses: burnett01/rsync-deployments@5.1
       with:
         switches: -avzr --delete
         path: src/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ The following versions are currently being supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.0   | :white_check_mark: |
+| 5.x   | :white_check_mark: |
 | 4.1   | :white_check_mark: |
 | 4.0   | :white_check_mark: |
 | 3.0   | :white_check_mark: |


### PR DESCRIPTION
Updates the base image (drinternet/rsync) from version v1.2.0 to v1.3.0 to reflect the underlaying base image version update (Alpine v3.11 to v3.14.1 (latest)).

Merging is locked until I have conducted tests.