### PR TITLE
Re-allow RSA host keys with SSH

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ set -eu
 
 # Variables.
 SWITCHES="$INPUT_SWITCHES"
-RSH="ssh -o StrictHostKeyChecking=no -p $INPUT_REMOTE_PORT $INPUT_RSH"
+RSH="ssh -o StrictHostKeyChecking=no -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa -p $INPUT_REMOTE_PORT $INPUT_RSH"
 LOCAL_PATH="$GITHUB_WORKSPACE/$INPUT_PATH"
 DSN="$INPUT_REMOTE_USER@$INPUT_REMOTE_HOST"
 


### PR DESCRIPTION
RSA host keys are disabled by default on OpenSSH 8.8+ which is used by the base Alpine image, but many servers still use RSA host keys. See https://www.openssh.com/txt/release-8.8 under "Potentially-incompatible changes".

Obviously the ideal solution would be to upgrade OpenSSH on the destination servers, but that's not always feasible, so to allow this Github Action to work with older SSH servers, this pull requests adds the required ssh command line options to re-enable support for SSH host keys.

If you are using an up-to-date SSH server version, the option is ignored so this doesn't weaken security for anyone who is using a more secure server version.

Due to the way the entrypoint.sh script is written, I don't know that there's any better way to set these SSH command line options - you cannot override the "-e" option on the rsync command line using the "switches" variable as it gets overwritten after the switches are specified.