### PR TITLE
Bump drinternet/rsync from v1.4.0 to v1.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drinternet/rsync:v1.4.0
+FROM drinternet/rsync:v1.4.1
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Bumps drinternet/rsync from v1.4.0 to v1.4.1.

---
updated-dependencies:
- dependency-name: drinternet/rsync
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>