### PR TITLE
Backmerge unofficial release/5.3 into new upcoming rlease/7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Version 4.0 & 4.1 use the ``drinternet/rsync:1.0.1`` base-image.
 
 ---
 
-## Version 3.0
+## Version 3.0 (EOL)
 
 Looking for version 3.0?
 


### PR DESCRIPTION
This PR backmerges/cherry-picks the RSA Host keys fix from #24 from the unofficial release/5.3 into the new upcoming release/7.0.0.

