### PR TITLE
Release/7.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drinternet/rsync:v1.4.3
+FROM drinternet/rsync:v1.4.4
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -158,7 +158,15 @@ See [#49](https://github.com/Burnett01/rsync-deployments/issues/49) and [#24](ht
 
 ---
 
-## Version 5.0, 5.1 & 5.2
+## Version 6.0 (MAINTENANCE)
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/6.0  (alpine 3.17.2)
+
+---
+
+## Version 5.0, 5.1 & 5.2 & 5.x (DEPRECATED)
 
 Check here: 
 
@@ -167,10 +175,10 @@ Check here:
 - https://github.com/Burnett01/rsync-deployments/tree/5.2  (alpine 3.15.0)
 - https://github.com/Burnett01/rsync-deployments/tree/5.2.1  (alpine 3.16.1)
 - https://github.com/Burnett01/rsync-deployments/tree/5.2.2  (alpine 3.17.2)
-- 
+
 ---
 
-## Version 4.0 & 4.1
+## Version 4.0 & 4.1 (EOL)
 
 Check here: 
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         path: src/
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete --exclude="" --include="" --filter=""
         path: src/
@@ -96,7 +96,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         path: src/
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         path: src/
@@ -142,7 +142,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         legacy_allow_rsa_hostkeys: "true"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub Action (amd64) deploys files in `GITHUB_WORKSPACE` to a remote folde
 
 Use this action in a CD workflow which leaves deployable code in `GITHUB_WORKSPACE`.
 
-The base-image [drinternet/rsync](https://github.com/JoshPiper/rsync-docker/) of this action is very small and is based on Alpine 3.17.2 (no cache) which results in fast deployments.
+The base-image [drinternet/rsync](https://github.com/JoshPiper/rsync-docker/) of this action is very small and is based on Alpine 3.19.1 (no cache) which results in fast deployments.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The base-image [drinternet/rsync](https://github.com/JoshPiper/rsync-docker/) of
 
 - `rsh` - Remote shell commands
 
+- `legacy_allow_rsa_hostkeys` - Enables support for legacy RSA host keys on OpenSSH 8.8+. ("true" / "false")
+
 - `path` - The source path. Defaults to GITHUB_WORKSPACE and is relative to it
 
 - `remote_path`* - The deployment target path
@@ -125,6 +127,35 @@ jobs:
         remote_key: ${{ secrets.DEPLOY_KEY }}
         remote_key_pass: ${{ secrets.DEPLOY_KEY_PASS }}
 ```
+
+---
+
+#### Legacy RSA Hostkeys support for OpenSSH Servers >= 8.8+
+
+If your remote OpenSSH Server still uses RSA hostkeys, then you have to
+manually enable legacy support for this by using ``legacy_allow_rsa_hostkeys: "true"``.
+
+```
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: rsync deployments
+      uses: burnett01/rsync-deployments@6.0.0
+      with:
+        switches: -avzr --delete
+        legacy_allow_rsa_hostkeys: "true"
+        path: src/
+        remote_path: ${{ secrets.DEPLOY_PATH }}
+        remote_host: ${{ secrets.DEPLOY_HOST }}
+        remote_port: ${{ secrets.DEPLOY_PORT }}
+        remote_user: ${{ secrets.DEPLOY_USER }}
+        remote_key: ${{ secrets.DEPLOY_KEY }}
+```
+
+See [#49](https://github.com/Burnett01/rsync-deployments/issues/49) and [#24](https://github.com/Burnett01/rsync-deployments/issues/24) for more information.
+
 ---
 
 ## Version 5.0, 5.1 & 5.2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,12 +6,13 @@ The following versions are currently being supported with security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 6.x   | :white_check_mark: |
-| 5.x   | :white_check_mark: |
-| 4.x   | :white_check_mark: |
-| 3.0   | :x: |
-| 2.0   | :x:                |
-| 1.0   | :x:                |
+| 7.x   | :white_check_mark: |
+| 6.x   | :information_source: MAINTENANCE |
+| 5.x   | :warning: DEPRECATED |
+| 4.x   | :x: EOL |
+| 3.0   | :x: EOL |
+| 2.0   | :x: EOL               |
+| 1.0   | :x: EOL               |
 
 ## Reporting a Vulnerability
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'The remote shell argument'
     required: false
     default: ''
+  legacy_allow_rsa_hostkeys:
+    description: 'Enables support for legacy RSA host keys on OpenSSH 8.8+'
+    required: false
+    default: 'false'
   path:
     description: 'The local path'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,11 @@ echo "$INPUT_REMOTE_KEY" | SSH_PASS="$INPUT_REMOTE_KEY_PASS" agent-add
 set -eu
 
 # Variables.
+LEGACY_RSA_HOSTKEYS="-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa"
+LEGACY_RSA_HOSTKEYS=$([ "$INPUT_LEGACY_ALLOW_RSA_HOSTKEYS" = "true" ] && echo "$LEGACY_RSA_HOSTKEYS" || echo "")
+
 SWITCHES="$INPUT_SWITCHES"
-RSH="ssh -o StrictHostKeyChecking=no -o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa -p $INPUT_REMOTE_PORT $INPUT_RSH"
+RSH="ssh -o StrictHostKeyChecking=no $LEGACY_RSA_HOSTKEYS -p $INPUT_REMOTE_PORT $INPUT_RSH"
 LOCAL_PATH="$GITHUB_WORKSPACE/$INPUT_PATH"
 DSN="$INPUT_REMOTE_USER@$INPUT_REMOTE_HOST"
 


### PR DESCRIPTION
- [feat: Update base image to latest 1.4.4 (alpine 3.19.1)](https://github.com/Burnett01/rsync-deployments/commit/ee287eb1f090f838d05d64cf0e798b74dbc619fd)

https://github.com/JoshPiper/rsync-docker/commit/ba20622d48f9c6c153bf520408c17aaec887e817
https://github.com/JoshPiper/rsync-docker/pull/25

- [Merge pull request](https://github.com/Burnett01/rsync-deployments/commit/a078b62820a5a09b7a4daebe3145bbc73cef8e54) https://github.com/Burnett01/rsync-deployments/pull/24 [from jasongill/patch-1](https://github.com/Burnett01/rsync-deployments/commit/a078b62820a5a09b7a4daebe3145bbc73cef8e54) 

Re-allow RSA host keys with SSH
- [feat: Make usage of legacy rsa hostkeys conditional](https://github.com/Burnett01/rsync-deployments/commit/9603fc818619574f10c02c47431eb0a7edafef9a) 

The usage of RSA host keys introduced with https://github.com/Burnett01/rsync-deployments/commit/c7baefdc23c4bb3b517a16ffa6ddda31763f0be8 
was adjusted to make it conditional/configurable and to keep
backward compatibility

Resolves #49

- [feat: configuarable legacy RSA hostkeys support](https://github.com/Burnett01/rsync-deployments/commit/008719532fb1adf12fd09a5f271e7a170a85cbe5) 

Ability to configure legacy rsa hostkeys support for
OpenSSH servers >= 8.8.
Related to https://github.com/Burnett01/rsync-deployments/pull/24 and  https://github.com/Burnett01/rsync-deployments/commit/9603fc818619574f10c02c47431eb0a7edafef9a

- [chore!: Versions 4.x EOL, 5.x DEPRECATED, 6.x MAINTENANCE](https://github.com/Burnett01/rsync-deployments/commit/b9a68ac619de1a77314c0296dcb1ef6348ea93cf) 

> All versions 4.x are now EOL and no longer maintained
> All versions 5.x are now DEPRECATED and will become EOL within Q2 2024
> All versions  6.x are now MAINTENANCE and will become DEPRECATED within Q4 2024
