### PR TITLE
Use SHA instead of Docker version tag for base image to allow for consistent code execution.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM drinternet/rsync:v1.4.4
+# drinternet/rsync@v1.4.4
+FROM drinternet/rsync@sha256:15b2949838074bd93c49421c22380396a0cd53a322439e799ac87afcadcfe234
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
We're using this action for Apache Flink where we're required to review any custom actions. Fixing the base image version with the SHA256 hash instead of a version to would allow us to make sure that we're always execute the code that was reviewed.