### PR TITLE
Release/7.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM drinternet/rsync:v1.4.4
+# drinternet/rsync@v1.4.4
+FROM drinternet/rsync@sha256:15b2949838074bd93c49421c22380396a0cd53a322439e799ac87afcadcfe234
 
 # Copy entrypoint
 COPY entrypoint.sh /entrypoint.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2019-2022 Contention
-Copyright (c) 2019-2022 Burnett01
+Copyright (c) 2019-2024 Burnett01
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         path: src/
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete --exclude="" --include="" --filter=""
         path: src/
@@ -96,7 +96,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         path: src/
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         path: src/
@@ -142,7 +142,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@6.0.0
+      uses: burnett01/rsync-deployments@7.0.0
       with:
         switches: -avzr --delete
         legacy_allow_rsa_hostkeys: "true"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ This action needs secret variables for the ssh private key of your key pair. The
 
 For simplicity, we are using `DEPLOY_*` as the secret variables throughout the examples.
 
+## Current Version: 7.0.1
+
 ## Example usage
 
 Simple:
@@ -57,7 +59,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@7.0.0
+      uses: burnett01/rsync-deployments@7.0.1
       with:
         switches: -avzr --delete
         path: src/
@@ -76,7 +78,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@7.0.0
+      uses: burnett01/rsync-deployments@7.0.1
       with:
         switches: -avzr --delete --exclude="" --include="" --filter=""
         path: src/
@@ -96,7 +98,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@7.0.0
+      uses: burnett01/rsync-deployments@7.0.1
       with:
         switches: -avzr --delete
         path: src/
@@ -116,7 +118,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@7.0.0
+      uses: burnett01/rsync-deployments@7.0.1
       with:
         switches: -avzr --delete
         path: src/
@@ -142,7 +144,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@7.0.0
+      uses: burnett01/rsync-deployments@7.0.1
       with:
         switches: -avzr --delete
         legacy_allow_rsa_hostkeys: "true"


### PR DESCRIPTION
- Pin @JoshPiper [drinternet/rsync](https://github.com/JoshPiper/rsync-docker) image by SHA-256 hash rather than version.  (Immutability)
Added via #60 

The docker image of this action is now pinned to the specific SHA-256 hash of the version rather than just the version.
This means for the latest `drinternet/rsync:v1.4.4` the corresponding hash is `drinternet/rsync@sha256:15b2949838074bd93c49421c22380396a0cd53a322439e799ac87afcadcfe234`

Check for validation: https://hub.docker.com/layers/drinternet/rsync/v1.4.4/images/sha256-15b2949838074bd93c49421c22380396a0cd53a322439e799ac87afcadcfe234

With that, usage of this action is even more secure due to a consistent dependency chain of trust,
since changes accompanied by a docker image hash are immutable.

Thanks to @XComp 

