### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@
 # - Running a final integration check
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Burnett01/rsync-deployments/security/code-scanning/6](https://github.com/Burnett01/rsync-deployments/security/code-scanning/6)

The best way to fix this problem is to add an explicit `permissions:` block at the workflow level to restrict the access of the GITHUB_TOKEN to the least privileges required. Since none of the jobs or steps write to the repository, create, or modify issues or pull requests, the minimal safe permission is `contents: read` (enough for actions like `actions/checkout`). 

To implement this fix, edit `.github/workflows/ci.yml` and add the following block at the top level (recommended just after the `name: CI` line, before `on:`):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed; only this simple YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
