### PR TITLE
Release/8.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS base
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS base
 
 RUN apk update && apk add --no-cache --upgrade rsync openssh openssl busybox
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,8 @@
 MIT License
 
 Copyright (c) 2019-2022 Contention
-Copyright (c) 2019-2025 Joshua Piper (Dr Internet)
-Copyright (c) 2019-2025 Burnett01
+Copyright (c) 2019-2026 Joshua Piper (Dr Internet)
+Copyright (c) 2019-2026 Burnett01
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ This cross-platform GitHub Action deploys files in [`path`](#inputs) (relative t
 
 Use this action in a CD workflow which leaves deployable code in `GITHUB_WORKSPACE`, such [actions/checkout](https://github.com/actions/checkout).
 
-The base-image of this action is very small and based on **Alpine 3.23.3** (no cache) which results in fast deployments.
+The base-image of this action is very small and based on **Alpine 3.23.4** (no cache) which results in fast deployments.
 
-Alpine version: [3.23.3](https://www.alpinelinux.org/posts/Alpine-3.20.9-3.21.6-3.22.3-3.23.3-released.html)
+Alpine version: [3.23.4](https://www.alpinelinux.org/posts/Alpine-3.20.10-3.21.7-3.22.4-3.23.4-released.html)
 Rsync version: [3.4.1-r1](https://download.samba.org/pub/rsync/NEWS#3.4.1)
 
-## Current Version: v8 (8.0.4)
+## Current Version: v8 (8.0.5)
 
 ### Release channels:
 
 | Version | Purpose          | Immutable  | 
 | ------- | ------------------ | ------------------ | 
 | ``v8`` (recommended)  |  latest MAJOR (pointer to 8.MINOR.PATCH) | no |
-| 8.0.4  | latest MINOR+PATCH | yes |
+| 8.0.5  | latest MINOR+PATCH | yes |
 | 7.1.0   | previous MAJOR+MINOR ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) | yes |
 | 7.0.2   | previous MAJOR+PATCH ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) | no |
 
@@ -285,6 +285,30 @@ sudo apk add rsync
 ---
 
 ## Versions
+
+## Version 8.0.4
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/8.0.4  (alpine 3.23.3)
+
+## Version 8.0.3
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/8.0.3  (alpine 3.23.2)
+
+## Version 8.0.2
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/8.0.2  (alpine 3.23.0)
+
+## Version 8.0.1 (EOL)
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/8.0.1  (alpine 3.23.0)
 
 ## Version 8.0.0 (EOL due to regression -> fixed via 8.0.1 & 8.0.2)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,11 @@ The following versions are currently being supported with security updates:
 
 | Version | Supported          | Rsync version          | Alpine version          | Support Until  |
 | ------- | ------------------ | ------------------ | ------------------ | ------------------ | 
-| (``v8``) 8.0.4  | :white_check_mark: | >= 3.4.1-r1 | 3.23.3 | LTS (2026-*) |
-| 8.0.3  | :white_check_mark: | >= 3.4.1-r1 | 3.23.2 | LTS (2026-*) |
-| 8.0.2  | :white_check_mark: | >= 3.4.1-r1 | 3.23.0 | LTS (2026-*) |
-| 8.0.1  | :white_check_mark: | >= 3.4.1-r1 | 3.23.0 | Apr, 1st 2026 |
+| (``v8``) 8.0.5  | :white_check_mark: | >= 3.4.1-r1 | 3.23.4 | LTS (2026-*) |
+| 8.0.4  | :white_check_mark: | >= 3.4.1-r1 | 3.23.3 | LTS (2026) |
+| 8.0.3  | :white_check_mark: | >= 3.4.1-r1 | 3.23.2 | LTS (2026) |
+| 8.0.2  | :white_check_mark: | >= 3.4.1-r1 | 3.23.0 | LTS (2026) |
+| 8.0.1  | :x: EOL | >= 3.4.1-r1 | 3.23.0 | † Apr, 1st 2026 |
 | 8.0.0  | :x: EOL (due to regression #90) | >= 3.4.1-r1 | 3.23.0 | † Dec, 6th 2025 |
 | 7.1.0  | :warning: DEPRECATED | >= 3.4.1-r0 | 3.22.1 | June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |
 | 7.0.2   | :warning: DEPRECATED | >= 3.4.0-r0 | 3.22.1 | June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |


### PR DESCRIPTION
- update base-image Alpine from 2.23.3 to 2.23.4 that fixes:

musl
CVE-2026-6042
CVE-2026-40200

openssl
CVE-2026-31790
CVE-2026-28387
CVE-2026-28388
CVE-2026-28389
CVE-2026-28390
CVE-2026-31789