### PR TITLE
chore: EOL of version 7.0.2 and 7.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,9 @@ Rsync version: [3.4.1-r1](https://download.samba.org/pub/rsync/NEWS#3.4.1)
 | Version | Purpose          | Immutable  | 
 | ------- | ------------------ | ------------------ | 
 | ``v8`` (recommended)  |  latest MAJOR (pointer to 8.MINOR.PATCH) | no |
-| 8.0.5  | latest MINOR+PATCH | yes |
-| 7.1.0   | previous MAJOR+MINOR ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) | yes |
-| 7.0.2   | previous MAJOR+PATCH ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) | no |
+| 8.0.5  | latest MAJOR+MINOR+PATCH | yes |
 
 Check [SECURITY.md](SECURITY.md) for support cycles.
-
 ---
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -316,14 +316,14 @@ Check here:
 
 - https://github.com/Burnett01/rsync-deployments/tree/8.0.0  (alpine 3.23.0)
 
-## Version 7.1.0
+## Version 7.1.0 (EOL)
 
 Check here: 
 
 - https://github.com/Burnett01/rsync-deployments/tree/7.1.0  (alpine 3.22.1)
   
 
-## Version 7.0.2 (DEPRECATED)
+## Version 7.0.2 (EOL)
 
 Check here: 
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,8 @@ The following versions are currently being supported with security updates:
 | 8.0.2  | :white_check_mark: | >= 3.4.1-r1 | 3.23.0 | LTS (2026) |
 | 8.0.1  | :x: EOL | >= 3.4.1-r1 | 3.23.0 | † Apr, 1st 2026 |
 | 8.0.0  | :x: EOL (due to regression #90) | >= 3.4.1-r1 | 3.23.0 | † Dec, 6th 2025 |
-| 7.1.0  | :warning: DEPRECATED | >= 3.4.1-r0 | 3.22.1 | June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |
-| 7.0.2   | :warning: DEPRECATED | >= 3.4.0-r0 | 3.22.1 | June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |
+| 7.1.0  | :x: EOL | >= 3.4.1-r0 | 3.22.1 | † June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |
+| 7.0.2   | :x: EOL | >= 3.4.0-r0 | 3.22.1 | † June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |
 | 7.0.1   | :x: EOL | < 3.4.0 | 3.22.1 | † Dec, 6th 2025 |
 | 7.0.0   | :x: EOL | < 3.4.0| 3.19.1 | † Dec, 6th 2025 |
 | 6.x   | :x: EOL |< 3.4.0| 3.17.2 | † 2024 |


### PR DESCRIPTION
As per #96 version 7.0.2 and 7.1.0 have reached their end of life after 6 months in deprecation phase.

Will be merged by June 1st.

