### PR TITLE
Release/9.0.0 (v9)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS base
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS base
 
 RUN apk update && apk add --no-cache --upgrade rsync openssh openssl busybox
 

--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ This cross-platform GitHub Action deploys files in [`path`](#inputs) (relative t
 
 Use this action in a CD workflow which leaves deployable code in `GITHUB_WORKSPACE`, such [actions/checkout](https://github.com/actions/checkout).
 
-The base-image of this action is very small and based on **Alpine 3.23.4** (no cache) which results in fast deployments.
+The base-image of this action is very small and based on **Alpine 3.24.1** (no cache) which results in fast deployments.
 
-Alpine version: [3.23.4](https://www.alpinelinux.org/posts/Alpine-3.20.10-3.21.7-3.22.4-3.23.4-released.html)
-Rsync version: [3.4.1-r1](https://download.samba.org/pub/rsync/NEWS#3.4.1)
+Alpine version: [3.23.4](https://www.alpinelinux.org/posts/Alpine-3.24.1-released.html)
+Rsync version: [3.4.3-r1](https://download.samba.org/pub/rsync/NEWS#3.4.3)
 
-## Current Version: v8 (8.0.5)
+## Current Version: v9 (9.0.0)
 
 ### Release channels:
 
 | Version | Purpose          | Immutable  | 
 | ------- | ------------------ | ------------------ | 
-| ``v8`` (recommended)  |  latest MAJOR (pointer to 8.MINOR.PATCH) | no |
-| 8.0.5  | latest MAJOR+MINOR+PATCH | yes |
+| ``v9`` (recommended, LTS)  |  latest MAJOR (pointer to 9.MINOR.PATCH) | no |
+| 9.0.0  | latest MAJOR+MINOR+PATCH | yes |
+| ``v8`` (ESU)  | previous MAJOR (pointer to 8.MINOR.PATCH) | no |
+| 8.0.5  | previous MAJOR+MINOR+PATCH | yes |
 
 Check [SECURITY.md](SECURITY.md) for support cycles.
 ---
@@ -39,9 +41,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@v8
+      uses: burnett01/rsync-deployments@v9
       with:
         switches: -avzr --delete
         path: src/
@@ -105,9 +107,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@v8
+      uses: burnett01/rsync-deployments@v9
       with:
         switches: -avzr --delete
         path: src/
@@ -125,9 +127,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@v8
+      uses: burnett01/rsync-deployments@v9
       with:
         switches: -avzr --delete --exclude="" --include="" --filter=""
         path: src/
@@ -145,9 +147,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@v8
+      uses: burnett01/rsync-deployments@v9
       with:
         switches: -avzr --delete
         path: src/
@@ -171,9 +173,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: rsync deployments
-      uses: burnett01/rsync-deployments@v8
+      uses: burnett01/rsync-deployments@v9
       with:
         switches: -avzr --delete
         legacy_allow_rsa_hostkeys: "true"
@@ -282,6 +284,12 @@ sudo apk add rsync
 ---
 
 ## Versions
+
+## Version 8.0.5
+
+Check here: 
+
+- https://github.com/Burnett01/rsync-deployments/tree/8.0.5  (alpine 3.23.4)
 
 ## Version 8.0.4
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Use this action in a CD workflow which leaves deployable code in `GITHUB_WORKSPA
 
 The base-image of this action is very small and based on **Alpine 3.24.1** (no cache) which results in fast deployments.
 
-Alpine version: [3.23.4](https://www.alpinelinux.org/posts/Alpine-3.24.1-released.html)
+Alpine version: [3.24.1](https://www.alpinelinux.org/posts/Alpine-3.24.1-released.html)
 Rsync version: [3.4.3-r1](https://download.samba.org/pub/rsync/NEWS#3.4.3)
 
 ## Current Version: v9 (9.0.0)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,11 @@ The following versions are currently being supported with security updates:
 
 | Version | Supported          | Rsync version          | Alpine version          | Support Until  |
 | ------- | ------------------ | ------------------ | ------------------ | ------------------ | 
-| (``v8``) 8.0.5  | :white_check_mark: | >= 3.4.1-r1 | 3.23.4 | LTS (2026-*) |
-| 8.0.4  | :white_check_mark: | >= 3.4.1-r1 | 3.23.3 | LTS (2026) |
-| 8.0.3  | :white_check_mark: | >= 3.4.1-r1 | 3.23.2 | LTS (2026) |
-| 8.0.2  | :white_check_mark: | >= 3.4.1-r1 | 3.23.0 | LTS (2026) |
+| (``v9``) 9.0.0  | :white_check_mark: | >= 3.4.3-r1 | 3.24.1 | LTS (2028-*) |
+| (``v8``) 8.0.5  | :white_check_mark: | >= 3.4.1-r1 | 3.23.4 | ESU (Apr, 1st 2027) |
+| 8.0.4  | :white_check_mark: | >= 3.4.1-r1 | 3.23.3 | Dec, 6th 2026 |
+| 8.0.3  | :white_check_mark: | >= 3.4.1-r1 | 3.23.2 | Dec, 6th 2026 |
+| 8.0.2  | :white_check_mark: | >= 3.4.1-r1 | 3.23.0 | Dec, 6th 2026 |
 | 8.0.1  | :x: EOL | >= 3.4.1-r1 | 3.23.0 | † Apr, 1st 2026 |
 | 8.0.0  | :x: EOL (due to regression #90) | >= 3.4.1-r1 | 3.23.0 | † Dec, 6th 2025 |
 | 7.1.0  | :x: EOL | >= 3.4.1-r0 | 3.22.1 | † June, 1st 2026 ([deprecation notice](https://github.com/Burnett01/rsync-deployments/discussions/96)) |


### PR DESCRIPTION
## New Major v9

Since Alpine 3.24.x was released, we're bumping our major version from ``v8`` to **``v9``**.
Please take a look at our [release policy ](https://github.com/Burnett01/rsync-deployments/security/policy) for updated support cycles for ``v8`` and **``v9``**.

### v9 (9.0.0)

- Update Alpine base-image from 3.23.4 to **[3.24.1](https://www.alpinelinux.org/posts/Alpine-3.24.1-released.html)**
Alpine 3.24.x includes various features and security-fixes:
[CVE-2026-34180](https://security.alpinelinux.org/vuln/CVE-2026-34180)
[CVE-2026-34181](https://security.alpinelinux.org/vuln/CVE-2026-34181)
[CVE-2026-34182](https://security.alpinelinux.org/vuln/CVE-2026-34182)
[CVE-2026-34183](https://security.alpinelinux.org/vuln/CVE-2026-34183)
[CVE-2026-42764](https://security.alpinelinux.org/vuln/CVE-2026-42764)
[CVE-2026-42766](https://security.alpinelinux.org/vuln/CVE-2026-42766)
[CVE-2026-42767](https://security.alpinelinux.org/vuln/CVE-2026-42767)
[CVE-2026-42768](https://security.alpinelinux.org/vuln/CVE-2026-42768)
[CVE-2026-42769](https://security.alpinelinux.org/vuln/CVE-2026-42769)
[CVE-2026-42770](https://security.alpinelinux.org/vuln/CVE-2026-42770)
[CVE-2026-45445](https://security.alpinelinux.org/vuln/CVE-2026-45445)
[CVE-2026-45446](https://security.alpinelinux.org/vuln/CVE-2026-45446)
[CVE-2026-45447](https://security.alpinelinux.org/vuln/CVE-2026-45447)
[CVE-2026-7383](https://security.alpinelinux.org/vuln/CVE-2026-7383)
[CVE-2026-9076](https://security.alpinelinux.org/vuln/CVE-2026-9076)

- Update Alpine Rsync package from 3.4.1-r1 to **[3.4.3-r1](https://download.samba.org/pub/rsync/NEWS#3.4.3)**
Rsync 3.4.3 comes with many bug-fixes and security-fixes:
CVE-2026-29518
CVE-2026-43617
CVE-2026-43618
CVE-2026-43619
CVE-2026-43620
CVE-2026-45232